### PR TITLE
[feat] Calendar CRUD

### DIFF
--- a/readour/src/main/java/com/readour/common/controller/CalendarController.java
+++ b/readour/src/main/java/com/readour/common/controller/CalendarController.java
@@ -1,0 +1,137 @@
+package com.readour.common.controller;
+
+import com.readour.common.dto.ApiResponseDto;
+import com.readour.common.dto.CalendarEventCreateRequestDto;
+import com.readour.common.dto.CalendarEventResponseDto;
+import com.readour.common.dto.CalendarEventUpdateRequestDto;
+import com.readour.common.dto.ErrorResponseDto;
+import com.readour.common.enums.CalendarScope;
+import com.readour.common.service.CalendarService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "Personal Calendar", description = "개인 캘린더(일정) 관리 API")
+@RestController
+@RequestMapping("/api/calendar")
+@RequiredArgsConstructor
+@Validated
+public class CalendarController {
+
+    private final CalendarService calendarService;
+
+    @Operation(summary = "캘린더 조회 (월별/주별)",
+            description = "사용자의 캘린더 일정을 조회합니다. (viewType=WEEK 또는 MONTH, scope 파라미터 생략 시 USER+ROOM 모두 조회)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/events")
+    public ResponseEntity<ApiResponseDto<List<CalendarEventResponseDto>>> getEvents(
+            @RequestHeader("X-User-Id") Long userId, // TODO: 인증 기능으로 교체
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            @Schema(description = "조회 기준 날짜", example = "2025-11-10")
+            LocalDate viewDate,
+            @RequestParam(defaultValue = "MONTH")
+            @Schema(description = "조회 타입", example = "WEEK", allowableValues = {"MONTH", "WEEK"})
+            String viewType,
+            @RequestParam(required = false)
+            @Schema(description = "조회 범위 (USER 또는 ROOM). 생략 시 모두 조회", example = "USER")
+            CalendarScope scope
+    ) {
+        List<CalendarEventResponseDto> events = calendarService.getEvents(userId, viewDate, viewType, scope);
+
+        return ResponseEntity.ok(ApiResponseDto.<List<CalendarEventResponseDto>>builder()
+                .status(HttpStatus.OK.value())
+                .body(events)
+                .message("캘린더 일정 목록 조회 성공")
+                .build());
+    }
+
+    @Operation(summary = "상세 일정 조회", description = "개인 일정 1개를 상세 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "일정을 찾을 수 없거나 조회 권한이 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
+    @GetMapping("/events/{eventId}")
+    public ResponseEntity<ApiResponseDto<CalendarEventResponseDto>> getEventDetail(
+            @PathVariable Long eventId,
+            @RequestHeader("X-User-Id") Long userId // TODO: 인증 기능으로 교체
+    ) {
+        CalendarEventResponseDto event = calendarService.getEventDetail(eventId, userId);
+        return ResponseEntity.ok(ApiResponseDto.<CalendarEventResponseDto>builder()
+                .status(HttpStatus.OK.value())
+                .body(event)
+                .message("개인 일정 상세 조회 성공")
+                .build());
+    }
+
+    @Operation(summary = "개인 일정 추가", description = "개인 캘린더에 새 일정을 추가합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "일정 추가 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류 (날짜 오류 등)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
+    @PostMapping("/events")
+    public ResponseEntity<ApiResponseDto<CalendarEventResponseDto>> createEvent(
+            @RequestHeader("X-User-Id") Long userId, // TODO: 인증 기능으로 교체
+            @Valid @RequestBody CalendarEventCreateRequestDto requestDto
+    ) {
+        CalendarEventResponseDto event = calendarService.createEvent(userId, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseDto.<CalendarEventResponseDto>builder()
+                .status(HttpStatus.CREATED.value())
+                .body(event)
+                .message("개인 일정이 추가되었습니다.")
+                .build());
+    }
+
+    @Operation(summary = "일정 수정", description = "자신이 생성한 개인 일정이나 OWNER나 MANAGER인 팀의 일정을 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "일정 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류 (날짜 오류 등)"),
+            @ApiResponse(responseCode = "404", description = "일정을 찾을 수 없거나 수정 권한이 없음")
+    })
+    @PutMapping("/events/{eventId}")
+    public ResponseEntity<ApiResponseDto<CalendarEventResponseDto>> updateEvent(
+            @PathVariable Long eventId,
+            @RequestHeader("X-User-Id") Long userId, // TODO: 인증 기능으로 교체
+            @Valid @RequestBody CalendarEventUpdateRequestDto requestDto
+    ) {
+        CalendarEventResponseDto event = calendarService.updateEvent(eventId, userId, requestDto);
+        return ResponseEntity.ok(ApiResponseDto.<CalendarEventResponseDto>builder()
+                .status(HttpStatus.OK.value())
+                .body(event)
+                .message("일정이 수정되었습니다.")
+                .build());
+    }
+
+    @Operation(summary = "일정 삭제", description = "자신이 생성한 개인 일정이나 OWNER나 MANAGER인 팀의 일정을 삭제합니다. (Soft Delete)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "일정 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "일정을 찾을 수 없거나 삭제 권한이 없음")
+    })
+    @DeleteMapping("/events/{eventId}")
+    public ResponseEntity<ApiResponseDto<Void>> deleteEvent(
+            @PathVariable Long eventId,
+            @RequestHeader("X-User-Id") Long userId // TODO: 인증 기능으로 교체
+    ) {
+        calendarService.deleteEvent(eventId, userId);
+        return ResponseEntity.ok(ApiResponseDto.<Void>builder()
+                .status(HttpStatus.OK.value())
+                .message("일정이 삭제되었습니다.")
+                .build());
+    }
+}

--- a/readour/src/main/java/com/readour/common/dto/CalendarEventCreateRequestDto.java
+++ b/readour/src/main/java/com/readour/common/dto/CalendarEventCreateRequestDto.java
@@ -1,0 +1,36 @@
+package com.readour.common.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Schema(description = "개인 일정 생성 요청 DTO")
+public class CalendarEventCreateRequestDto {
+
+    @NotBlank(message = "일정 제목은 필수입니다.")
+    @Schema(description = "일정 제목", example = "개인 독서 시간")
+    private String title;
+
+    @Schema(description = "일정 상세 설명", example = "'아몬드' 1~5챕터 읽기")
+    private String description;
+
+    @Schema(description = "장소", example = "집 앞 카페")
+    private String location;
+
+    @NotNull(message = "시작 시각은 필수입니다.")
+    @Schema(description = "일정 시작 시각", example = "2025-11-10T14:00:00")
+    private LocalDateTime startsAt;
+
+    @NotNull(message = "종료 시각은 필수입니다.")
+    @Schema(description = "일정 종료 시각", example = "2025-11-10T16:00:00")
+    private LocalDateTime endsAt;
+
+    @Schema(description = "하루 종일 여부", example = "false")
+    private Boolean allDay = false;
+}

--- a/readour/src/main/java/com/readour/common/dto/CalendarEventResponseDto.java
+++ b/readour/src/main/java/com/readour/common/dto/CalendarEventResponseDto.java
@@ -1,0 +1,63 @@
+package com.readour.common.dto;
+
+import com.readour.common.entity.CalendarEvent;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "일정 응답 DTO")
+public class CalendarEventResponseDto {
+
+    @Schema(description = "일정 ID", example = "1")
+    private Long eventId;
+
+    @Schema(description = "캘린더 ID", example = "10")
+    private Long calendarId;
+
+    @Schema(description = "일정 제목", example = "개인 독서 시간")
+    private String title;
+
+    @Schema(description = "일정 상세 설명", example = "'아몬드' 1~5챕터 읽기")
+    private String description;
+
+    @Schema(description = "장소", example = "집 앞 카페")
+    private String location;
+
+    @Schema(description = "일정 시작 시각")
+    private LocalDateTime startsAt;
+
+    @Schema(description = "일정 종료 시각")
+    private LocalDateTime endsAt;
+
+    @Schema(description = "하루 종일 여부")
+    private Boolean allDay;
+
+    @Schema(description = "생성자 ID", example = "1")
+    private Long createdBy;
+
+    @Schema(description = "생성 시각")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 시각")
+    private LocalDateTime updatedAt;
+
+    public static CalendarEventResponseDto fromEntity(CalendarEvent event) {
+        return CalendarEventResponseDto.builder()
+                .eventId(event.getEventId())
+                .calendarId(event.getCalendarId())
+                .title(event.getTitle())
+                .description(event.getDescription())
+                .location(event.getLocation())
+                .startsAt(event.getStartsAt())
+                .endsAt(event.getEndsAt())
+                .allDay(event.getAllDay())
+                .createdBy(event.getCreatedBy())
+                .createdAt(event.getCreatedAt())
+                .updatedAt(event.getUpdatedAt())
+                .build();
+    }
+}

--- a/readour/src/main/java/com/readour/common/dto/CalendarEventUpdateRequestDto.java
+++ b/readour/src/main/java/com/readour/common/dto/CalendarEventUpdateRequestDto.java
@@ -1,0 +1,31 @@
+package com.readour.common.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Schema(description = "개인 일정 수정 요청 DTO")
+public class CalendarEventUpdateRequestDto {
+
+    @Schema(description = "일정 제목", example = "개인 독서 시간 (변경)")
+    private String title;
+
+    @Schema(description = "일정 상세 설명", example = "'아몬드' 1~7챕터 읽기")
+    private String description;
+
+    @Schema(description = "장소", example = "집")
+    private String location;
+
+    @Schema(description = "일정 시작 시각", example = "2025-11-10T15:00:00")
+    private LocalDateTime startsAt;
+
+    @Schema(description = "일정 종료 시각", example = "2025-11-10T17:00:00")
+    private LocalDateTime endsAt;
+
+    @Schema(description = "하루 종일 여부", example = "false")
+    private Boolean allDay;
+}

--- a/readour/src/main/java/com/readour/common/repository/CalendarEventRepository.java
+++ b/readour/src/main/java/com/readour/common/repository/CalendarEventRepository.java
@@ -1,9 +1,12 @@
 package com.readour.common.repository;
 
 import com.readour.common.entity.CalendarEvent;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Long> {
@@ -14,4 +17,9 @@ public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Lo
                                                                              String title,
                                                                              LocalDateTime startsAt,
                                                                              LocalDateTime endsAt);
+
+    List<CalendarEvent> findAllByCalendarIdInAndIsDeletedFalseAndStartsAtLessThanEqualAndEndsAtGreaterThanEqual(
+            Collection<Long> calendarIds, LocalDateTime rangeEnd, LocalDateTime rangeStart, Sort sort);
+
+    Optional<CalendarEvent> findByEventIdAndCreatedByAndIsDeletedFalse(Long eventId, Long createdBy);
 }

--- a/readour/src/main/java/com/readour/common/repository/CalendarRepository.java
+++ b/readour/src/main/java/com/readour/common/repository/CalendarRepository.java
@@ -4,6 +4,8 @@ import com.readour.common.entity.Calendar;
 import com.readour.common.enums.CalendarScope;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface CalendarRepository extends JpaRepository<Calendar, Long> {
@@ -11,4 +13,5 @@ public interface CalendarRepository extends JpaRepository<Calendar, Long> {
     Optional<Calendar> findByScopeAndRelatedRoomId(CalendarScope scope, Long relatedRoomId);
 
     Optional<Calendar> findFirstByOwnerUserIdAndScope(Long ownerUserId, CalendarScope scope);
+    List<Calendar> findByScopeAndRelatedRoomIdIn(CalendarScope scope, Collection<Long> roomIds);
 }

--- a/readour/src/main/java/com/readour/common/service/CalendarService.java
+++ b/readour/src/main/java/com/readour/common/service/CalendarService.java
@@ -1,0 +1,288 @@
+package com.readour.common.service;
+
+import com.readour.chat.entity.ChatRoomMember;
+import com.readour.chat.repository.ChatRoomMemberRepository;
+import com.readour.common.dto.CalendarEventCreateRequestDto;
+import com.readour.common.dto.CalendarEventResponseDto;
+import com.readour.common.dto.CalendarEventUpdateRequestDto;
+import com.readour.common.entity.Calendar;
+import com.readour.common.entity.CalendarEvent;
+import com.readour.common.enums.CalendarScope;
+import com.readour.common.enums.ErrorCode;
+import com.readour.common.enums.Role;
+import com.readour.common.exception.CustomException;
+import com.readour.common.repository.CalendarEventRepository;
+import com.readour.common.repository.CalendarRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CalendarService {
+
+    private final CalendarRepository calendarRepository;
+    private final CalendarEventRepository calendarEventRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    /**
+     * (SD-22) 캘린더 조회 (월별/주별)
+     */
+    @Transactional(readOnly = true)
+    public List<CalendarEventResponseDto> getEvents(Long userId, LocalDate viewDate, String viewType, CalendarScope scope) {
+        // 1. 조회 범위 계산 (기존과 동일)
+        LocalDateTime startDate;
+        LocalDateTime endDate;
+        if ("WEEK".equalsIgnoreCase(viewType)) {
+            LocalDate weekStart = viewDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+            LocalDate weekEnd = weekStart.plusDays(6);
+            startDate = weekStart.atStartOfDay();
+            endDate = weekEnd.atTime(LocalTime.MAX);
+        } else { // "MONTH" (기본값)
+            LocalDate monthStart = viewDate.withDayOfMonth(1);
+            LocalDate monthEnd = viewDate.with(TemporalAdjusters.lastDayOfMonth());
+            startDate = monthStart.atStartOfDay();
+            endDate = monthEnd.atTime(LocalTime.MAX);
+        }
+
+        log.debug("GetEvents userId: {}, Scope: {}, Range: {} ~ {}", userId, scope, startDate, endDate);
+
+        // 2. [신규] 조회할 캘린더 ID 목록 집계
+        List<Long> targetCalendarIds = new ArrayList<>();
+
+        // 2-1. USER 스코프 추가 (기존 로직)
+        if (scope == null || scope == CalendarScope.USER) {
+            findUserCalendar(userId).ifPresent(cal -> targetCalendarIds.add(cal.getCalendarId()));
+        }
+
+        // 2-2. ROOM 스코프 추가
+        if (scope == null || scope == CalendarScope.ROOM) {
+            // 사용자가 속한 모든 활성 채팅방 ID 조회
+            List<Long> roomIds = chatRoomMemberRepository.findAllByUserIdAndIsActiveTrue(userId).stream()
+
+                    .map(ChatRoomMember::getRoomId)
+                    .toList();
+
+            if (!roomIds.isEmpty()) {
+                // 채팅방 ID에 연결된 ROOM 캘린더 ID들 조회
+                List<Long> roomCalendarIds = calendarRepository.findByScopeAndRelatedRoomIdIn(CalendarScope.ROOM, roomIds).stream()
+                        .map(Calendar::getCalendarId)
+                        .toList();
+                targetCalendarIds.addAll(roomCalendarIds);
+            }
+        }
+
+        // 3. 캘린더 ID가 없으면 빈 리스트 반환
+        if (targetCalendarIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 4. 통합된 캘린더 ID 목록으로 기간 내 이벤트 조회
+        Sort sort = Sort.by(Sort.Direction.ASC, "startsAt");
+        List<CalendarEvent> events = calendarEventRepository
+                .findAllByCalendarIdInAndIsDeletedFalseAndStartsAtLessThanEqualAndEndsAtGreaterThanEqual(
+                        targetCalendarIds, endDate, startDate, sort);
+
+        return events.stream()
+                .map(CalendarEventResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 상세 일정 조회
+     */
+    @Transactional(readOnly = true)
+    public CalendarEventResponseDto getEventDetail(Long eventId, Long userId) {
+        // 1. 이벤트 ID로 이벤트 조회
+        CalendarEvent event = calendarEventRepository.findById(eventId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "일정을 찾을 수 없습니다."));
+
+        // 2. 이벤트의 캘린더(소유 정보) 조회
+        Calendar calendar = calendarRepository.findById(event.getCalendarId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "일정의 캘린더(소유자) 정보를 찾을 수 없습니다."));
+
+        // 3. 통합 권한 검증
+        validateEventPermission(calendar, userId);
+
+        // 4. DTO 반환
+        return CalendarEventResponseDto.fromEntity(event);
+    }
+
+    /**
+     * (SD-23) 일정 추가
+     */
+    @Transactional
+    public CalendarEventResponseDto createEvent(Long userId, CalendarEventCreateRequestDto dto) {
+        LocalDateTime now = LocalDateTime.now();
+        // 1. 개인 캘린더 조회 (없으면 생성)
+        Calendar userCalendar = getOrCreateUserCalendar(userId, now);
+
+        if (dto.getStartsAt().isAfter(dto.getEndsAt())) {
+            throw new CustomException(ErrorCode.BAD_REQUEST, "종료 시각은 시작 시각보다 빠를 수 없습니다.");
+        }
+
+        // 2. 이벤트 엔티티 생성
+        CalendarEvent event = CalendarEvent.builder()
+                .calendarId(userCalendar.getCalendarId())
+                .title(dto.getTitle())
+                .description(dto.getDescription())
+                .location(dto.getLocation())
+                .startsAt(dto.getStartsAt())
+                .endsAt(dto.getEndsAt())
+                .allDay(dto.getAllDay() != null ? dto.getAllDay() : false)
+                .createdBy(userId)
+                .isDeleted(false)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+
+        CalendarEvent savedEvent = calendarEventRepository.save(event);
+        log.info("Personal CalendarEvent created. eventId: {}, userId: {}", savedEvent.getEventId(), userId);
+
+        return CalendarEventResponseDto.fromEntity(savedEvent);
+    }
+
+    /**
+     * (SD-24) 일정 수정
+     */
+    @Transactional
+    public CalendarEventResponseDto updateEvent(Long eventId, Long userId, CalendarEventUpdateRequestDto dto) {
+        // 1. 이벤트 및 캘린더 조회, 통합 권한 검증
+        CalendarEvent event = validateEventModificationPermission(eventId, userId);
+
+        // 2. 값 변경 (Dirty checking)
+        if (dto.getTitle() != null) event.setTitle(dto.getTitle());
+        if (dto.getDescription() != null) event.setDescription(dto.getDescription());
+        if (dto.getLocation() != null) event.setLocation(dto.getLocation());
+        if (dto.getStartsAt() != null) event.setStartsAt(dto.getStartsAt());
+        if (dto.getEndsAt() != null) event.setEndsAt(dto.getEndsAt());
+        if (dto.getAllDay() != null) event.setAllDay(dto.getAllDay());
+
+        event.setUpdatedAt(LocalDateTime.now());
+
+        if (event.getStartsAt().isAfter(event.getEndsAt())) {
+            throw new CustomException(ErrorCode.BAD_REQUEST, "종료 시각은 시작 시각보다 빠를 수 없습니다.");
+        }
+
+        return CalendarEventResponseDto.fromEntity(event);
+    }
+
+    /**
+     * (SD-25) 일정 삭제
+     */
+    @Transactional
+    public void deleteEvent(Long eventId, Long userId) {
+        // 1. 이벤트 및 캘린더 조회, 통합 권한 검증
+        CalendarEvent event = validateEventModificationPermission(eventId, userId);
+
+        // 2. Soft Delete
+        event.setIsDeleted(true);
+        event.setUpdatedAt(LocalDateTime.now());
+
+        log.info("CalendarEvent soft-deleted. eventId: {}, userId: {}", event.getEventId(), userId);
+    }
+
+
+    /**
+     * [Helper] 사용자의 개인 캘린더(Scope.USER)를 찾거나, 없으면 생성합니다.
+     */
+    private Calendar getOrCreateUserCalendar(Long ownerId, LocalDateTime now) {
+        return calendarRepository.findFirstByOwnerUserIdAndScope(ownerId, CalendarScope.USER)
+                .orElseGet(() -> {
+                    log.info("Creating new personal calendar for userId: {}", ownerId);
+                    Calendar newCalendar = Calendar.builder()
+                            .ownerUserId(ownerId)
+                            .scope(CalendarScope.USER)
+                            .name("개인 캘린더") // (DC-23)
+                            .createdAt(now)
+                            .updatedAt(now)
+                            .build();
+                    return calendarRepository.save(newCalendar);
+                });
+    }
+
+    /**
+     * [HELPER] 사용자의 개인 캘린더(Scope.USER)를 조회합니다. (Read-Only)
+     */
+    private Optional<Calendar> findUserCalendar(Long ownerId) {
+        return calendarRepository.findFirstByOwnerUserIdAndScope(ownerId, CalendarScope.USER);
+    }
+
+    /**
+     * 통합 권한 검증 로직
+     */
+    private void validateEventPermission(Calendar calendar, Long userId) {
+        boolean hasPermission = false;
+
+        if (calendar.getScope() == CalendarScope.USER) {
+            // USER 스코프: 캘린더 소유자(ownerUserId)가 본인(userId)인지 확인
+            hasPermission = calendar.getOwnerUserId().equals(userId);
+
+        } else if (calendar.getScope() == CalendarScope.ROOM) {
+            // ROOM 스코프: 해당 채팅방(relatedRoomId)의 '활성 멤버'인지 확인
+            hasPermission = chatRoomMemberRepository
+                    .findByRoomIdAndUserIdAndIsActiveTrue(calendar.getRelatedRoomId(), userId)
+                    .isPresent();
+
+        } else if (calendar.getScope() == CalendarScope.GLOBAL) {
+            hasPermission = true; // GLOBAL은 모두에게 허용 (정책)
+        }
+
+        if (!hasPermission) {
+            throw new CustomException(ErrorCode.FORBIDDEN, "해당 일정에 접근할 권한이 없습니다.");
+        }
+    }
+
+    /**
+     * [Helper] (수정/삭제 권한) 캘린더 일정 '수정/삭제' 권한 검증
+     * USER: 일정 생성자
+     * ROOM: 채팅방 Owner or Manager
+     */
+    private CalendarEvent validateEventModificationPermission(Long eventId, Long userId) {
+        // 1. 이벤트 조회
+        CalendarEvent event = calendarEventRepository.findById(eventId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "일정을 찾을 수 없습니다."));
+
+        // 2. 캘린더 조회
+        Calendar calendar = calendarRepository.findById(event.getCalendarId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "일정의 캘린더(소유자) 정보를 찾을 수 없습니다."));
+
+        // 3. 권한 검증
+        if (calendar.getScope() == CalendarScope.USER) {
+            // USER 스코프: 생성자(createdBy)와 요청자(userId)가 일치해야 함
+            if (!event.getCreatedBy().equals(userId)) {
+                throw new CustomException(ErrorCode.FORBIDDEN, "개인 일정은 생성자만 수정/삭제할 수 있습니다.");
+            }
+        } else if (calendar.getScope() == CalendarScope.ROOM) {
+            // ROOM 스코프: 채팅방의 'Owner' 또는 'Manager'여야 함
+            ChatRoomMember member = chatRoomMemberRepository
+                    .findByRoomIdAndUserIdAndIsActiveTrue(calendar.getRelatedRoomId(), userId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.FORBIDDEN, "채팅방 멤버가 아니므로 수정/삭제 권한이 없습니다."));
+
+            // [정책 수정] MEMBER는 안되고, OWNER 또는 MANAGER만 가능
+            if (member.getRole() != Role.OWNER && member.getRole() != Role.MANAGER) {
+                throw new CustomException(ErrorCode.FORBIDDEN, "일정 수정/삭제는 방장 또는 매니저만 가능합니다.");
+            }
+        } else {
+            // GLOBAL 등 기타
+            throw new CustomException(ErrorCode.FORBIDDEN, "해당 일정은 수정/삭제할 수 없습니다.");
+        }
+
+        // 4. 권한이 있으면 이벤트 반환
+        return event;
+    }
+}


### PR DESCRIPTION
#29 
- 캘린더 조회 (월간, 주간)
- 일정 추가(개인 캘린더)
- 일정 수정(개인 캘린더. 룸 캘린더의 경우 방장이나 매니저만)
- 일정 삭제(개인 캘린더. 룸 캘린더의 경우 방장이나 매니저만)
- 일정 조회(개인+룸/개인/룸) 글로벌은 없는 취급함 일단.